### PR TITLE
Add failing test for optional decode

### DIFF
--- a/tests/PipelineTests.elm
+++ b/tests/PipelineTests.elm
@@ -43,6 +43,15 @@ optionalWrongStructure =
                 |> Expect.equal (Errors (Nonempty (Failure "Expected an object" (Encode.list [])) []))
 
 
+optionalUnusedField : Test
+optionalUnusedField =
+    test "decoding an optional field in an object with one other field should warn about other field" <|
+        \_ ->
+            """ { "a": 1 } """
+                |> decodeString (decode identity |> optional "b" string "hi")
+                |> Expect.equal (WithWarnings (Nonempty (UnusedValue (Encode.object [ ( "a", Encode.int 1 ) ])) []) "hi")
+
+
 optionalAtWrongStructure : Test
 optionalAtWrongStructure =
     let


### PR DESCRIPTION
Hey, thanks for looking at the empty object issue and for the changes, but I think those changes introduce a problem with decoding optional entries in objects with other fields.

I believe the 'Decode.keyValuePairs Decode.value' [here](https://github.com/zwilias/json-decode-exploration/blob/4a4312afac813edd12720d9bfdc5b6315959a01c/src/Json/Decode/Exploration/Pipeline.elm#L180) is going to mark everything as 'used' and so fail to pass this test. I might be wrong though!