### PR TITLE
`Located`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [
         "Json.Decode.Exploration",
+        "Json.Decode.Exploration.Located",
         "Json.Decode.Exploration.Pipeline"
     ],
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "scripts": {
+        "test:local": "elm-verify-examples && elm-test",
         "test": "elm-format --validate src && elm-verify-examples && npm run coverage",
         "coverage": "elm-coverage --report codecov --elm-test ./node_modules/.bin/elm-test && codecov --disable=gcov -f .coverage/codecov.json"
     },

--- a/src/Json/Decode/Exploration.elm
+++ b/src/Json/Decode/Exploration.elm
@@ -47,9 +47,31 @@ module Json.Decode.Exploration
         , warningsToString
         )
 
-{-| Like the regular decoders, except
+{-| This package presents a somewhat experimental approach to JSON decoding. Its
+API looks very much like the core `Json.Decode` API. The major differences are
+the final `decodeString` and `decodeValue` functions, which return a
+`DecodeResult a`.
 
-Examples assume imports:
+Decoding with this library can result in one of 4 possible outcomes:
+
+  - The input wasn't valid JSON
+  - One or more errors occured
+  - Decoding succeeded but produced warnings
+  - Decoding succeeded without warnings
+
+Both the `Errors` and `Warnings` types are (mostly) machine readable: they are
+implemented as a recursive datastructure that points to the location of the
+error in the input json, producing information about what went wrong (i.e. "what
+was the expected type, and what did the actual value look like").
+
+Further, this library also adds a few extra `Decoder`s that help with making
+assertions about the structure of the JSON while decoding.
+
+For convenience, this library also includes a `Json.Decode.Exploration.Pipeline`
+module which is largely a copy of [`NoRedInk/elm-decode-pipeline`][edp].
+
+All the examples in the documentation are verified by
+[`elm-verify-examples`][eve] and assume the following imports:
 
     import Json.Encode as Encode
     import Json.Decode.Exploration exposing (..)
@@ -58,15 +80,31 @@ Examples assume imports:
     import Array
     import Dict
 
-
-# Run Decoders
-
-@docs decodeString, decodeValue, DecodeResult, Value, Errors, Error, Warnings, Warning, ExpectedType
+[eve]: https://github.com/stoeffel/elm-verify-examples#readme
+[edp]: http://package.elm-lang.org/packages/NoRedInk/elm-decode-pipeline/latest
 
 
-# Dealing with warnings and errors
+# Running a `Decoder`
 
-@docs strict, errorsToString, warningsToString
+Runing a `Decoder` works largely the same way as it does in the familiar core
+library. There is one serious caveat, however:
+
+> This library does **not** allowing decoding non-serializable JS values.
+
+This means that trying to use this library to decode a `Value` which contains
+non-serializable information like `function`s will not work. It will, however,
+result in a `BadJson` result.
+
+Trying to use this library on cyclic values (like HTML events) is quite likely
+to blow up completely. Don't try this, except maybe at home.
+
+@docs decodeString, decodeValue, strict, DecodeResult, Value
+
+
+## Dealing with warnings and errors
+
+@docs Errors, Error, errorsToString, Warnings, Warning, warningsToString
+@docs ExpectedType
 
 
 # Primitives
@@ -132,7 +170,7 @@ type alias Value =
 {-| Decoding may fail with 1 or more errors, so `Errors` is a
 [`Nonempty`][nonempty] of errors.
 
-[nonempty]: TODO
+[nonempty]: http://package.elm-lang.org/packages/mgold/elm-nonempty-list/latest/List-Nonempty
 
 -}
 type alias Errors =

--- a/src/Json/Decode/Exploration.elm
+++ b/src/Json/Decode/Exploration.elm
@@ -38,6 +38,7 @@ module Json.Decode.Exploration
         , null
         , nullable
         , oneOf
+        , strictResult
         , string
         , succeed
         , value
@@ -63,7 +64,7 @@ Examples assume imports:
 
 # Dealing with warnings and errors
 
-@docs warningsToString
+@docs strictResult, warningsToString
 
 
 # Primitives
@@ -1283,6 +1284,7 @@ toResult res =
             Ok v
 
 
+{-| -}
 strictResult : DecodeResult a -> Result String a
 strictResult res =
     case res of
@@ -1303,14 +1305,22 @@ strictResult res =
 warningsToString : Warnings -> String
 warningsToString warnings =
     "While I was able to decode this JSON successfully, I did produce one or more warnings:"
+        :: ""
         :: Located.toString warningToString warnings
+        |> List.map String.trimRight
         |> String.join "\n"
 
 
 warningToString : Warning -> List String
 warningToString (UnusedValue v) =
     "I encountered an unused value here. Are you sure you don't need this?"
-        :: jsonLines v
+        :: ""
+        :: (indent <| jsonLines v)
+
+
+indent : List String -> List String
+indent =
+    List.map ((++) "  ")
 
 
 jsonLines : Value -> List String
@@ -1321,6 +1331,7 @@ jsonLines =
 errorsToString : Errors -> String
 errorsToString errors =
     "I encountered some erors while decoding this JSON:"
+        :: ""
         :: errorsToStrings errors
         |> String.join "\n"
 
@@ -1342,4 +1353,6 @@ errorToString error =
                     [ "I encountered a oneOf without any options" ]
 
                 _ ->
-                    "I encountered multiple issues" :: List.concatMap errorsToStrings errors
+                    "I encountered multiple issues"
+                        :: ""
+                        :: List.concatMap errorsToStrings errors

--- a/src/Json/Decode/Exploration.elm
+++ b/src/Json/Decode/Exploration.elm
@@ -1313,7 +1313,7 @@ warningsToString warnings =
 
 warningToString : Warning -> List String
 warningToString (UnusedValue v) =
-    "I encountered an unused value here. Are you sure you don't need this?"
+    "Unused value:"
         :: ""
         :: (indent <| jsonLines v)
 

--- a/src/Json/Decode/Exploration/Located.elm
+++ b/src/Json/Decode/Exploration/Located.elm
@@ -58,33 +58,7 @@ flatten located =
 gather : String -> Nonempty (Located a) -> List ( String, List a )
 gather prefix (Nonempty first rest) =
     List.concatMap flatten (first :: rest)
-        |> group
         |> List.map (Tuple.mapFirst ((++) prefix))
-
-
-group : List ( String, List a ) -> List ( String, List a )
-group =
-    List.foldr
-        (\( key, item ) { keys, items } ->
-            if Set.member key keys then
-                { keys = keys
-                , items =
-                    List.map
-                        (\( k, v ) ->
-                            if k == key then
-                                ( k, item ++ v )
-                            else
-                                ( k, v )
-                        )
-                        items
-                }
-            else
-                { keys = Set.insert key keys
-                , items = ( key, item ) :: items
-                }
-        )
-        { keys = Set.empty, items = [] }
-        >> .items
 
 
 map : (a -> b) -> Located a -> Located b

--- a/src/Json/Decode/Exploration/Located.elm
+++ b/src/Json/Decode/Exploration/Located.elm
@@ -15,7 +15,7 @@ toString itemToString locatedItems =
     locatedItems
         |> gather ""
         |> List.map (uncurry <| render itemToString)
-        |> intercalate "And also"
+        |> intercalate ""
 
 
 intercalate : a -> List (List a) -> List a
@@ -25,9 +25,16 @@ intercalate sep lists =
 
 render : (a -> List String) -> String -> List a -> List String
 render itemToString path errors =
-    List.concatMap itemToString errors
-        |> List.map indent
-        |> (::) ("At path " ++ path)
+    let
+        formattedErrors : List String
+        formattedErrors =
+            List.concatMap itemToString errors
+                |> List.map indent
+    in
+    if String.isEmpty path then
+        formattedErrors
+    else
+        ("At path " ++ path) :: "" :: formattedErrors
 
 
 indent : String -> String

--- a/src/Json/Decode/Exploration/Located.elm
+++ b/src/Json/Decode/Exploration/Located.elm
@@ -1,0 +1,93 @@
+module Json.Decode.Exploration.Located exposing (..)
+
+import List.Nonempty as Nonempty exposing (Nonempty(..))
+import Set exposing (Set)
+
+
+type Located a
+    = InField String (Nonempty (Located a))
+    | AtIndex Int (Nonempty (Located a))
+    | Pure a
+
+
+toString : (a -> List String) -> Nonempty (Located a) -> List String
+toString itemToString locatedItems =
+    locatedItems
+        |> gather ""
+        |> List.map (uncurry <| render itemToString)
+        |> intercalate "And also"
+
+
+intercalate : a -> List (List a) -> List a
+intercalate sep lists =
+    lists |> List.intersperse [ sep ] |> List.concat
+
+
+render : (a -> List String) -> String -> List a -> List String
+render itemToString path errors =
+    List.concatMap itemToString errors
+        |> List.map indent
+        |> (::) ("At path " ++ path)
+
+
+indent : String -> String
+indent =
+    (++) "  "
+
+
+flatten : Located a -> List ( String, List a )
+flatten located =
+    case located of
+        Pure v ->
+            [ ( "", [ v ] ) ]
+
+        InField s vals ->
+            gather ("/" ++ s) vals
+
+        AtIndex i vals ->
+            gather ("/" ++ Basics.toString i) vals
+
+
+gather : String -> Nonempty (Located a) -> List ( String, List a )
+gather prefix (Nonempty first rest) =
+    List.concatMap flatten (first :: rest)
+        |> group
+        |> List.map (Tuple.mapFirst ((++) prefix))
+
+
+group : List ( String, List a ) -> List ( String, List a )
+group =
+    List.foldr
+        (\( key, item ) { keys, items } ->
+            if Set.member key keys then
+                { keys = keys
+                , items =
+                    List.map
+                        (\( k, v ) ->
+                            if k == key then
+                                ( k, item ++ v )
+                            else
+                                ( k, v )
+                        )
+                        items
+                }
+            else
+                { keys = Set.insert key keys
+                , items = ( key, item ) :: items
+                }
+        )
+        { keys = Set.empty, items = [] }
+        >> .items
+
+
+map : (a -> b) -> Located a -> Located b
+map op located =
+    case located of
+        InField f val ->
+            InField f <| Nonempty.map (map op) val
+
+        AtIndex i val ->
+            AtIndex i <| Nonempty.map (map op) val
+
+        Pure v ->
+            Pure (op v)

--- a/src/Json/Decode/Exploration/Pipeline.elm
+++ b/src/Json/Decode/Exploration/Pipeline.elm
@@ -257,8 +257,9 @@ the decoder to succeed.
     expectedErrors : Errors
     expectedErrors =
         Failure "Verification failed, expected 'True'."  (Encode.bool False)
+            |> Pure
             |> Nonempty.fromElement
-            |> BadField "enabled"
+            |> InField "enabled"
             |> Nonempty.fromElement
 
 -}

--- a/src/Json/Decode/Exploration/Pipeline.elm
+++ b/src/Json/Decode/Exploration/Pipeline.elm
@@ -43,6 +43,7 @@ The examples all expect imports set up like this:
 
     import Json.Decode.Exploration exposing (..)
     import Json.Decode.Exploration.Pipeline exposing (..)
+    import Json.Decode.Exploration.Located exposing (Located(..))
     import Json.Encode as Encode
     import List.Nonempty as Nonempty
 

--- a/src/Json/Decode/Exploration/Pipeline.elm
+++ b/src/Json/Decode/Exploration/Pipeline.elm
@@ -257,7 +257,7 @@ the decoder to succeed.
 
     expectedErrors : Errors
     expectedErrors =
-        Failure "Verification failed, expected 'True'."  (Encode.bool False)
+        Failure "Verification failed, expected 'True'."  (Just <| Encode.bool False)
             |> Pure
             |> Nonempty.fromElement
             |> InField "enabled"

--- a/tests/PipelineTests.elm
+++ b/tests/PipelineTests.elm
@@ -2,6 +2,7 @@ module PipelineTests exposing (..)
 
 import Expect exposing (Expectation)
 import Json.Decode.Exploration as Decode exposing (..)
+import Json.Decode.Exploration.Located exposing (Located(..))
 import Json.Decode.Exploration.Pipeline exposing (..)
 import Json.Encode as Encode
 import List.Nonempty as Nonempty exposing (Nonempty(..))

--- a/tests/PipelineTests.elm
+++ b/tests/PipelineTests.elm
@@ -37,9 +37,10 @@ optionalEmptyStructure =
 optionalUnusedField : Test
 optionalUnusedField =
     let
-        expectedWarnings : Nonempty Warning
+        expectedWarnings : Warnings
         expectedWarnings =
             UnusedValue (Encode.int 1)
+                |> Pure
                 |> Nonempty.fromElement
                 |> InField "a"
                 |> Nonempty.fromElement
@@ -57,19 +58,20 @@ optionalWrongStructure =
         \_ ->
             """ [] """
                 |> decodeString (decode identity |> optional "foo" string "hi")
-                |> Expect.equal (Errors (Nonempty (Failure "Expected an object" (Encode.list [])) []))
+                |> Expect.equal (Errors (Nonempty (Pure <| Failure "Expected an object" (Encode.list [])) []))
 
 
 optionalAtWrongStructure : Test
 optionalAtWrongStructure =
     let
-        expectedErrors : Nonempty Error
+        expectedErrors : Errors
         expectedErrors =
             Failure "Expected an object" (Encode.list [])
+                |> Pure
                 |> Nonempty.fromElement
-                |> BadField "b"
+                |> InField "b"
                 |> Nonempty.fromElement
-                |> BadField "a"
+                |> InField "a"
                 |> Nonempty.fromElement
     in
     test "Using optionalAt where a field on the path is of an unexpected type fails" <|

--- a/tests/PipelineTests.elm
+++ b/tests/PipelineTests.elm
@@ -59,7 +59,7 @@ optionalWrongStructure =
         \_ ->
             """ [] """
                 |> decodeString (decode identity |> optional "foo" string "hi")
-                |> Expect.equal (Errors (Nonempty (Pure <| Failure "Expected an object" (Encode.list [])) []))
+                |> Expect.equal (Errors (Nonempty (Pure <| Expected TObject (Encode.list [])) []))
 
 
 optionalAtWrongStructure : Test
@@ -67,7 +67,7 @@ optionalAtWrongStructure =
     let
         expectedErrors : Errors
         expectedErrors =
-            Failure "Expected an object" (Encode.list [])
+            Expected TObject (Encode.list [])
                 |> Pure
                 |> Nonempty.fromElement
                 |> InField "b"

--- a/tests/SimpleTests.elm
+++ b/tests/SimpleTests.elm
@@ -7,10 +7,10 @@ import Json.Decode.Exploration as Decode
         , Decoder
         , Error(..)
         , Errors
-        , Located(..)
         , Warning(..)
         , Warnings
         )
+import Json.Decode.Exploration.Located exposing (Located(..))
 import Json.Encode as Encode
 import List.Nonempty as Nonempty exposing (Nonempty(..))
 import Native.TestHelpers

--- a/tests/SimpleTests.elm
+++ b/tests/SimpleTests.elm
@@ -1,7 +1,16 @@
 module SimpleTests exposing (..)
 
 import Expect exposing (Expectation)
-import Json.Decode.Exploration as Decode exposing (Decoder)
+import Json.Decode.Exploration as Decode
+    exposing
+        ( DecodeResult(..)
+        , Decoder
+        , Error(..)
+        , Errors
+        , Located(..)
+        , Warning(..)
+        , Warnings
+        )
 import Json.Encode as Encode
 import List.Nonempty as Nonempty exposing (Nonempty(..))
 import Native.TestHelpers
@@ -25,15 +34,15 @@ unusedSimpleValues =
 unusedValueTest : Encode.Value -> Test
 unusedValueTest value =
     let
-        warnings : Decode.Warnings
+        warnings : Warnings
         warnings =
-            Nonempty (Decode.UnusedValue value) []
+            Nonempty (Pure <| UnusedValue value) []
     in
     test (Encode.encode 0 value) <|
         \_ ->
             value
                 |> Decode.decodeValue (Decode.succeed ())
-                |> Expect.equal (Decode.WithWarnings warnings ())
+                |> Expect.equal (WithWarnings warnings ())
 
 
 simpleUnexpectedTypes : Test
@@ -62,17 +71,17 @@ simpleUnexpectedTypes =
 simpleUnexpectedType : Encode.Value -> Decoder () -> String -> Test
 simpleUnexpectedType value decoder expected =
     let
-        expectedErrors : Decode.Errors
+        expectedErrors : Errors
         expectedErrors =
             Nonempty
-                (Decode.Failure expected value)
+                (Pure <| Failure expected value)
                 []
     in
     test ("Given: " ++ Encode.encode 0 value ++ ", expected: " ++ expected) <|
         \_ ->
             value
                 |> Decode.decodeValue decoder
-                |> Expect.equal (Decode.Errors expectedErrors)
+                |> Expect.equal (Errors expectedErrors)
 
 
 
@@ -104,7 +113,7 @@ simpleRecursiveTest =
         """
                 |> Decode.decodeString treeDecoder
                 |> Expect.equal
-                    (Decode.Success
+                    (Success
                         (Branch
                             [ Leaf "1"
                             , Branch [ Leaf "2", Leaf "3" ]
@@ -132,7 +141,7 @@ map2Test =
         \_ ->
             """ [ 1, 2 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 3)
+                |> Expect.equal (Success 3)
 
 
 map3Test : Test
@@ -150,7 +159,7 @@ map3Test =
         \_ ->
             """ [ 1, 2, 3 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 6)
+                |> Expect.equal (Success 6)
 
 
 map4Test : Test
@@ -169,7 +178,7 @@ map4Test =
         \_ ->
             """ [ 1, 2, 3, 4 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 10)
+                |> Expect.equal (Success 10)
 
 
 map5Test : Test
@@ -189,7 +198,7 @@ map5Test =
         \_ ->
             """ [ 1, 2, 3, 4, 5 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 15)
+                |> Expect.equal (Success 15)
 
 
 map6Test : Test
@@ -210,7 +219,7 @@ map6Test =
         \_ ->
             """ [ 1, 2, 3, 4, 5, 6 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 21)
+                |> Expect.equal (Success 21)
 
 
 map7Test : Test
@@ -232,7 +241,7 @@ map7Test =
         \_ ->
             """ [ 1, 2, 3, 4, 5, 6, 7 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 28)
+                |> Expect.equal (Success 28)
 
 
 map8Test : Test
@@ -255,7 +264,7 @@ map8Test =
         \_ ->
             """ [ 1, 2, 3, 4, 5, 6, 7, 8 ] """
                 |> Decode.decodeString decoder
-                |> Expect.equal (Decode.Success 36)
+                |> Expect.equal (Success 36)
 
 
 
@@ -277,7 +286,7 @@ noUnusedValuesWithValueHelper value =
         \_ ->
             value
                 |> Decode.decodeValue (Decode.map (always ()) Decode.value)
-                |> Expect.equal (Decode.Success ())
+                |> Expect.equal (Success ())
 
 
 
@@ -290,7 +299,7 @@ functionInValueIsBad =
         \_ ->
             Native.TestHelpers.jsonWithFunction
                 |> Decode.decodeValue Decode.value
-                |> Expect.equal Decode.BadJson
+                |> Expect.equal BadJson
 
 
 
@@ -300,14 +309,14 @@ functionInValueIsBad =
 listCollectsErrors : Test
 listCollectsErrors =
     let
-        badIndex : Int -> Decode.Error
+        badIndex : Int -> Located Error
         badIndex idx =
-            Decode.BadIndex idx <|
+            AtIndex idx <|
                 Nonempty
-                    (Decode.Failure "Expected a string" (Encode.int idx))
+                    (Pure <| Failure "Expected a string" (Encode.int idx))
                     []
 
-        expectedErrors : Decode.Errors
+        expectedErrors : Errors
         expectedErrors =
             Nonempty (badIndex 0) [ badIndex 1 ]
     in
@@ -315,20 +324,20 @@ listCollectsErrors =
         \_ ->
             """ [ 0, 1 ] """
                 |> Decode.decodeString (Decode.list Decode.string)
-                |> Expect.equal (Decode.Errors expectedErrors)
+                |> Expect.equal (Errors expectedErrors)
 
 
 indexPropagatesErrors : Test
 indexPropagatesErrors =
     let
-        badIndex : Int -> Decode.Error
+        badIndex : Int -> Located Error
         badIndex idx =
-            Decode.BadIndex idx <|
+            AtIndex idx <|
                 Nonempty
-                    (Decode.Failure "Expected a string" (Encode.int idx))
+                    (Pure <| Failure "Expected a string" (Encode.int idx))
                     []
 
-        expectedErrors : Decode.Errors
+        expectedErrors : Errors
         expectedErrors =
             Nonempty (badIndex 0) []
     in
@@ -336,20 +345,20 @@ indexPropagatesErrors =
         \_ ->
             """ [ 0, 1 ] """
                 |> Decode.decodeString (Decode.index 0 Decode.string)
-                |> Expect.equal (Decode.Errors expectedErrors)
+                |> Expect.equal (Errors expectedErrors)
 
 
 keyValuePairsCollectsErrors : Test
 keyValuePairsCollectsErrors =
     let
-        badField : String -> Decode.Error
+        badField : String -> Located Error
         badField field =
-            Decode.BadField field <|
+            InField field <|
                 Nonempty
-                    (Decode.Failure "Expected a string" Encode.null)
+                    (Pure <| Failure "Expected a string" Encode.null)
                     []
 
-        expectedErrors : Decode.Errors
+        expectedErrors : Errors
         expectedErrors =
             Nonempty (badField "foo") [ badField "bar" ]
     in
@@ -357,7 +366,7 @@ keyValuePairsCollectsErrors =
         \_ ->
             """ { "foo": null, "hello": "world", "bar": null } """
                 |> Decode.decodeString (Decode.keyValuePairs Decode.string)
-                |> Expect.equal (Decode.Errors expectedErrors)
+                |> Expect.equal (Errors expectedErrors)
 
 
 
@@ -367,23 +376,23 @@ keyValuePairsCollectsErrors =
 map2CombineErrors : Test
 map2CombineErrors =
     let
-        badIndex : Int -> Decode.Error
+        badIndex : Int -> Located Error
         badIndex idx =
-            Decode.BadIndex idx <|
+            AtIndex idx <|
                 Nonempty
-                    (Decode.Failure "Expected an integer number" Encode.null)
+                    (Pure <| Failure "Expected an integer number" Encode.null)
                     []
     in
-    [ ( """ [ null, null ] """, Decode.Errors <| Nonempty (badIndex 0) [ badIndex 1 ] )
-    , ( """ [ 1, null ] """, Decode.Errors <| Nonempty (badIndex 1) [] )
-    , ( """ [ null, 1 ] """, Decode.Errors <| Nonempty (badIndex 0) [] )
-    , ( """ [ 1, 2] """, Decode.Success 3 )
+    [ ( """ [ null, null ] """, Errors <| Nonempty (badIndex 0) [ badIndex 1 ] )
+    , ( """ [ 1, null ] """, Errors <| Nonempty (badIndex 1) [] )
+    , ( """ [ null, 1 ] """, Errors <| Nonempty (badIndex 0) [] )
+    , ( """ [ 1, 2] """, Success 3 )
     ]
         |> List.map (uncurry map2CombineErrorsCase)
         |> describe "map2 combines errors"
 
 
-map2CombineErrorsCase : String -> Decode.DecodeResult Int -> Test
+map2CombineErrorsCase : String -> DecodeResult Int -> Test
 map2CombineErrorsCase input expected =
     test input <|
         \_ ->
@@ -410,9 +419,9 @@ andThenPreservesErrors =
             "null"
                 |> Decode.decodeString decoder
                 |> Expect.equal
-                    (Decode.Errors <|
+                    (Errors <|
                         Nonempty
-                            (Decode.Failure "Expected a string" Encode.null)
+                            (Pure <| Failure "Expected a string" Encode.null)
                             []
                     )
 
@@ -420,15 +429,16 @@ andThenPreservesErrors =
 decodingAFieldDoesNotMarkTheOthersAsUsed : Test
 decodingAFieldDoesNotMarkTheOthersAsUsed =
     let
-        expectedWarnings : Nonempty Decode.Warning
+        expectedWarnings : Warnings
         expectedWarnings =
-            Decode.UnusedValue Encode.null
+            UnusedValue Encode.null
+                |> Pure
                 |> Nonempty.fromElement
-                |> Decode.InField "baz"
+                |> InField "baz"
                 |> Nonempty.fromElement
     in
     test "Decoding a single field generates unused warnings for the other fields" <|
         \_ ->
             """ { "foo": "bar", "baz": null } """
                 |> Decode.decodeString (Decode.field "foo" Decode.string)
-                |> Expect.equal (Decode.WithWarnings expectedWarnings "bar")
+                |> Expect.equal (WithWarnings expectedWarnings "bar")

--- a/tests/StringifierTests.elm
+++ b/tests/StringifierTests.elm
@@ -127,3 +127,174 @@ simpleError =
                 |> decodeString string
                 |> errors
                 |> Expect.equal (Just expectedErrors)
+
+
+failError : Test
+failError =
+    let
+        expectedErrors =
+            formatError """
+  Failure all around!
+
+    {}
+"""
+    in
+    test "fail error" <|
+        \_ ->
+            """ {} """
+                |> decodeString (fail "Failure all around!")
+                |> errors
+                |> Expect.equal (Just expectedErrors)
+
+
+emptyOneOf : Test
+emptyOneOf =
+    let
+        expectedErrors =
+            formatError """
+  I encountered a `oneOf` without any options.
+"""
+    in
+    test "Empty oneOf" <|
+        \_ ->
+            """ null """
+                |> decodeString (oneOf [])
+                |> errors
+                |> Expect.equal (Just expectedErrors)
+
+
+multipleOneOfErrors : Test
+multipleOneOfErrors =
+    let
+        expectedErrors =
+            formatError """
+  I encountered multiple issues:
+
+    I expected a string here, but instead found this value:
+
+      null
+
+    I expected an integer number here, but instead found this value:
+
+      null
+
+    I expected a number here, but instead found this value:
+
+      null
+
+    I expected a boolean here, but instead found this value:
+
+      null
+
+    I expected an object here, but instead found this value:
+
+      null
+
+    I expected an array here, but instead found this value:
+
+      null
+
+    foo
+
+      null
+
+    I expected an object here, but instead found this value:
+
+      null
+
+    I expected an array here, but instead found this value:
+
+      null
+"""
+
+        decoder : Decoder ()
+        decoder =
+            oneOf
+                [ map (always ()) string
+                , map (always ()) int
+                , map (always ()) float
+                , map (always ()) bool
+                , map (always ()) (keyValuePairs string)
+                , map (always ()) (list string)
+                , map (always ()) (fail "foo")
+                , isObject
+                , isArray
+                ]
+    in
+    test "Multiple oneOf errors" <|
+        \_ ->
+            """ null """
+                |> decodeString decoder
+                |> errors
+                |> Expect.equal (Just expectedErrors)
+
+
+missingField : Test
+missingField =
+    let
+        expectedErrors =
+            formatError """
+  I expected an object with a field 'foo' here, but instead found this value:
+
+    {}
+"""
+    in
+    test "Missing field" <|
+        \_ ->
+            """ {} """
+                |> decodeString (field "foo" string)
+                |> errors
+                |> Expect.equal (Just expectedErrors)
+
+
+missingIndex : Test
+missingIndex =
+    let
+        expectedErrors =
+            formatError """
+  I expected an array with index 0 here, but instead found this value:
+
+    []
+"""
+    in
+    test "Missing index" <|
+        \_ ->
+            """ [] """
+                |> decodeString (index 0 string)
+                |> errors
+                |> Expect.equal (Just expectedErrors)
+
+
+expectedNull : Test
+expectedNull =
+    let
+        expectedErrors =
+            formatError """
+  I expected null here, but instead found this value:
+
+    "foobar"
+"""
+    in
+    test "Expected null" <|
+        \_ ->
+            """ "foobar" """
+                |> decodeString (null "hi")
+                |> errors
+                |> Expect.equal (Just expectedErrors)
+
+
+badJSON : Test
+badJSON =
+    let
+        expectedErrors =
+            formatError """
+  Invalid JSON
+"""
+    in
+    test "Bad JSON" <|
+        \_ ->
+            """ foobar """
+                |> decodeString string
+                |> strict
+                |> Result.mapError errorsToString
+                |> Expect.equal (Err expectedErrors)

--- a/tests/StringifierTests.elm
+++ b/tests/StringifierTests.elm
@@ -1,0 +1,54 @@
+module StringifierTests exposing (..)
+
+import Expect
+import Json.Decode.Exploration exposing (..)
+import Test exposing (..)
+
+
+formatWarning : String -> String
+formatWarning =
+    (++) "While I was able to decode this JSON successfully, I did produce one or more warnings:\n" >> String.trim
+
+
+simpleWarning : Test
+simpleWarning =
+    test "simple warning" <|
+        \_ ->
+            let
+                expectedError =
+                    formatWarning """
+  I encountered an unused value here. Are you sure you don't need this?
+
+    []
+"""
+            in
+            """ [] """
+                |> decodeString (succeed "hi")
+                |> strictResult
+                |> Expect.equal (Err expectedError)
+
+
+multipleWarnings : Test
+multipleWarnings =
+    let
+        expectedError =
+            formatWarning """
+At path /foo
+
+  I encountered an unused value here. Are you sure you don't need this?
+
+    "bar"
+
+At path /baz
+
+  I encountered an unused value here. Are you sure you don't need this?
+
+    "klux"
+"""
+    in
+    test "multiple warnings" <|
+        \_ ->
+            """ { "foo": "bar", "baz": "klux" } """
+                |> decodeString isObject
+                |> strictResult
+                |> Expect.equal (Err expectedError)

--- a/tests/StringifierTests.elm
+++ b/tests/StringifierTests.elm
@@ -17,7 +17,7 @@ simpleWarning =
             let
                 expectedError =
                     formatWarning """
-  I encountered an unused value here. Are you sure you don't need this?
+  Unused value:
 
     []
 """
@@ -35,13 +35,13 @@ multipleWarnings =
             formatWarning """
 At path /foo
 
-  I encountered an unused value here. Are you sure you don't need this?
+  Unused value:
 
     "bar"
 
 At path /baz
 
-  I encountered an unused value here. Are you sure you don't need this?
+  Unused value:
 
     "klux"
 """
@@ -50,5 +50,37 @@ At path /baz
         \_ ->
             """ { "foo": "bar", "baz": "klux" } """
                 |> decodeString isObject
+                |> strictResult
+                |> Expect.equal (Err expectedError)
+
+
+nestedWarnings : Test
+nestedWarnings =
+    let
+        expectedError =
+            formatWarning """
+At path /root/0
+
+  Unused value:
+
+    "foo"
+
+At path /root/1
+
+  Unused value:
+
+    "bar"
+"""
+    in
+    test "nested warnings" <|
+        \_ ->
+            """
+             { "root":
+               [ "foo"
+               , "bar"
+               ]
+             }
+             """
+                |> decodeString (field "root" isArray)
                 |> strictResult
                 |> Expect.equal (Err expectedError)


### PR DESCRIPTION
By using a `Located` type to capture the paths through the json data for both error and warnings, we can share infra for stringifying.