### PR TITLE
Feature/relevant json

### DIFF
--- a/src/Json/Decode/Exploration.elm
+++ b/src/Json/Decode/Exploration.elm
@@ -265,6 +265,9 @@ decodeString decoder jsonString =
 
 
 {-| Reduce JSON down to what is needed to ensure decoding succeeds.
+
+Similar the [`stripString`](#stripString) docs for more details and an example.
+
 -}
 stripValue : Decoder a -> Value -> Result Errors Value
 stripValue (Decoder decoderFn) val =
@@ -292,6 +295,9 @@ stripValue (Decoder decoderFn) val =
     your Decoder doesn't depend on any parameters which
     will vary between at build-time and run-time or
     you will lose this guarantee.
+
+    You can also take a look at the `validateStrip` test
+    cases in [this test module](https://github.com/zwilias/json-decode-exploration/blob/master/tests/SimpleTests.elm).
 
     import Json.Decode.Exploration as Decode exposing (Decoder)
 

--- a/src/Json/Decode/Exploration.elm
+++ b/src/Json/Decode/Exploration.elm
@@ -282,6 +282,47 @@ stripValue (Decoder decoderFn) val =
 
 
 {-| Reduce JSON down to what is needed to ensure decoding succeeds.
+
+    This is useful if you are doing a build step where you want to
+    strip down your JSON data to the minimal amount needed by
+    your Decoder. Because of the purity of Elm's functions,
+    you can safely strip out unused data assuming that you
+    use the exact same Decoder to strip the JSON as you use
+    when you re-run it against the stripped JSON. Be sure
+    your Decoder doesn't depend on any parameters which
+    will vary between at build-time and run-time or
+    you will lose this guarantee.
+
+    import Json.Decode.Exploration as Decode exposing (Decoder)
+
+
+    jsonValue : String
+    jsonValue =
+        """
+        {
+        "topLevelUsed": 123,
+        "partiallyUsed": [
+            {"used": "Hi! This is read by Decode.index so this Object will be included.", "unused": "Please ignore me"},
+            {"used": "This whole Object is stripped out because it isn't read by Decode.index!", "unused": "This field is always ignored"}
+            ],
+         "unused": 456,
+         "nestedUnused": "This gets stripped out of the final JSON"
+        }
+        """
+
+    type alias Record = { num : Int, string : String }
+
+    decoder : Decoder Record
+    decoder =
+        Decode.map2 Record
+            (Decode.field "topLevelUsed" Decode.int)
+            (Decode.field "partiallyUsed" ( Decode.index 0 (Decode.field "used" Decode.string )))
+
+
+    Decode.stripString decoder jsonValue
+      |> Result.mapError Decode.errorsToString
+    --> Ok """{"topLevelUsed":123,"partiallyUsed":[{"used":"Hi! This is read by Decode.index so this Object will be included."}]}"""
+
 -}
 stripString : Decoder a -> String -> Result Errors String
 stripString decoder jsonString =

--- a/tests/SimpleTests.elm
+++ b/tests/SimpleTests.elm
@@ -501,6 +501,14 @@ strip =
         , validateStrip "Read index 1, so index 0 must exist"
             (Decode.index 1 Decode.string)
             """["foo", "bar"]"""
+        , validateStrip "Count array length but don't use values."
+            (Decode.list Decode.value
+                |> Decode.andThen
+                    (\list ->
+                        Decode.succeed (List.length list)
+                    )
+            )
+            """["foo", "bar"]"""
         , validateStrip "Usage from failing decoders is threaded through"
             (Decode.oneOf
                 [ Decode.list (Decode.succeed ())


### PR DESCRIPTION
I added a test case that I thought might be tricky, but it worked perfectly!

I inspect the values, and doing `andThen` with String values reduced the string down to empty string (`""`) so that the behavior was the same. This is safe because it reads that there is a value here (reading the count), but it doesn't have the ability to look into the value because it uses `Decode.value`. Nice work!

I also added an `elm-verify-examples` test case in the docs and a little description of why you might use `stripString`. And I put a reference to those docs in the `stripValue` docs.

As far as I can tell, this looks good to go to me. What do you think @zwilias, anything else to consider before releasing this?